### PR TITLE
Added pixel filter

### DIFF
--- a/Library/Engine.h
+++ b/Library/Engine.h
@@ -10,7 +10,8 @@
 enum Flags: Uint32 {
 	DEBUG_DRAWTIME = 1 << 0,
 	SHOW_WIREFRAME = 1 << 1,
-	FLAT_SHADING = 1 << 2
+	FLAT_SHADING = 1 << 2,
+	PIXEL_FILTER = 1 << 3
 };
 
 struct Camera {

--- a/Library/Rasterizer.h
+++ b/Library/Rasterizer.h
@@ -8,7 +8,7 @@ class Rasterizer {
 		Rasterizer(SDL_Renderer* renderer, int width, int height, bool shouldUsePerVertexColoration);
 		~Rasterizer();
 		void line(int x1, int y1, int x2, int y2);
-		void render(SDL_Renderer* renderer);
+		void render(SDL_Renderer* renderer, int sizeFactor);
 		void setColor(int R, int G, int B);
 		void setColor(Color* color);
 		void triangle(int x1, int y1, int x2, int y2, int x3, int y3);

--- a/README.md
+++ b/README.md
@@ -5,11 +5,15 @@ A software 3D rendering engine, written as an educational exercise.
 
 ### Features
 
-* 2x pixel size (render at half resolution, scale to window size without filtering)
 * Blender model support
 * Texture mapping
 * Parallelization
 * Light sources
+
+**Maybe:**
+
+* Ambient occlusion
+* Dynamic shadows
 
 ### Refactoring
 

--- a/Source/Engine.cpp
+++ b/Source/Engine.cpp
@@ -31,8 +31,11 @@ Engine::Engine(int width, int height, Uint32 flags) {
 		SDL_WINDOW_SHOWN
 	);
 
+	int rasterWidth = flags & PIXEL_FILTER ? width / 2 : width;
+	int rasterHeight = flags & PIXEL_FILTER ? height / 2 : height;
+
 	renderer = SDL_CreateRenderer(window, -1, flags & DEBUG_DRAWTIME ? 0 : SDL_RENDERER_PRESENTVSYNC);
-	rasterizer = new Rasterizer(renderer, width, height, flags & FLAT_SHADING ? false : true);
+	rasterizer = new Rasterizer(renderer, rasterWidth, rasterHeight, ~flags & FLAT_SHADING);
 
 	this->width = width;
 	this->height = height;
@@ -41,6 +44,7 @@ Engine::Engine(int width, int height, Uint32 flags) {
 
 Engine::~Engine() {
 	objects.clear();
+
 	delete rasterizer;
 
 	SDL_DestroyRenderer(renderer);
@@ -63,8 +67,12 @@ void Engine::delay(int ms) {
 }
 
 void Engine::draw() {
+	bool hasPixelFilter = flags & PIXEL_FILTER;
+	int fovScalar = (hasPixelFilter ? 250 : 500) * (360 / camera.fov);
+	int midpointX = width / (hasPixelFilter ? 4 : 2);
+	int midpointY = height / (hasPixelFilter ? 4 : 2);
+
 	RotationMatrix rotationMatrix = camera.getRotationMatrix();
-	int fovScalar = 500 * (360 / camera.fov);
 
 	for (int o = 0; o < objects.size(); o++) {
 		Object* object = objects.at(o);
@@ -85,8 +93,8 @@ void Engine::draw() {
 				Vec3 vertex = rotationMatrix * (relativeObjectPosition + polygon.vertices[i]->vector);
 				Vec3 unitVertex = vertex.unit();
 				float distortionCorrectedZ = unitVertex.z * std::abs(std::cos(unitVertex.x));
-				int x = (int)(fovScalar * unitVertex.x / (1 + unitVertex.z) + width / 2);
-				int y = (int)(fovScalar * -unitVertex.y / (1 + distortionCorrectedZ) + height / 2);
+				int x = (int)(fovScalar * unitVertex.x / (1 + unitVertex.z) + midpointX);
+				int y = (int)(fovScalar * -unitVertex.y / (1 + distortionCorrectedZ) + midpointY);
 				int depth = (int)vertex.z;
 
 				if (!isInView && depth > 0) {
@@ -112,7 +120,7 @@ void Engine::draw() {
 		});
 	}
 
-	rasterizer->render(renderer);
+	rasterizer->render(renderer, flags & PIXEL_FILTER ? 2 : 1);
 }
 
 int Engine::getPolygonCount() {

--- a/Source/Rasterizer.cpp
+++ b/Source/Rasterizer.cpp
@@ -120,9 +120,11 @@ void Rasterizer::line(int x1, int y1, int x2, int y2) {
 	}
 }
 
-void Rasterizer::render(SDL_Renderer* renderer) {
+void Rasterizer::render(SDL_Renderer* renderer, int sizeFactor = 1) {
+	SDL_Rect destinationRect = { 0, 0, sizeFactor * width, sizeFactor * height };
+
 	SDL_UpdateTexture(screenTexture, NULL, pixelBuffer, width * sizeof(Uint32));
-	SDL_RenderCopy(renderer, screenTexture, NULL, NULL);
+	SDL_RenderCopy(renderer, screenTexture, NULL, &destinationRect);
 	SDL_RenderPresent(renderer);
 	clear();
 }


### PR DESCRIPTION
Adds support for an optional `PIXEL_FILTER` `Engine` flag which enables the world to be rendered at half resolution, deliberately scaled up for a pixelated look.

Performance is obviously improved in this mode since raster space is 1/4 the area of the default resolution.

![pixel-filter](https://user-images.githubusercontent.com/9344964/51943325-d3860b80-23de-11e9-9e88-976d56ff57d1.png)
