### PR TITLE
Slight UIObject/UIText revision, fixing memory leaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,16 +10,12 @@ include_directories(Library)
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake-modules)
 
-if (WIN32)
-    set(SDL2_PATH "C:/mingw-dev/SDL2")
-endif(WIN32)
-
 # Find SDL2 and SDL2_ttf
 find_package(SDL2 REQUIRED)
 include_directories(${SDL2_INCLUDE_DIR})
 
 find_package(SDL2TTF REQUIRED)
-include_directories(${SDL2TTF_INCLUDE_DIRS})
+include_directories(${SDL2TTF_INCLUDE_DIR})
 
 set(SOURCE_FILES
     Source/main.cpp

--- a/Library/UI/UIObjects.h
+++ b/Library/UI/UIObjects.h
@@ -1,30 +1,36 @@
 #pragma once
 
 #include <string>
-
 #include <SDL.h>
-#include <SDL2/SDL_ttf.h>
-
+#include <SDL_ttf.h>
 #include <Objects.h>
 
 struct UIObject {
+	~UIObject();
+
 	void setPosition(int x, int y);
-	virtual void draw(SDL_Renderer* renderer) = 0;
+	void setRenderer(SDL_Renderer* renderer);
+	virtual void draw() = 0;
 
 protected:
-	SDL_Surface* m_surface;
-	SDL_Texture* m_texture;
+	SDL_Renderer* renderer = 0;
+	SDL_Texture* m_texture = 0;
 	SDL_Rect m_rect;
+
+	virtual void refresh() = 0;
+	void setTextureFromSurface(SDL_Surface* surface);
 };
 
 struct UIText : UIObject {
-	void draw(SDL_Renderer* renderer);
+	void draw();
 	void setFont(TTF_Font* font);
 	void setColor(const SDL_Color &color);
 	void setValue(const char* value);
 
-protected:
-	const char* m_value;
-	TTF_Font* m_font;
-	SDL_Color m_color;
+private:
+	const char* m_value = 0;
+	TTF_Font* m_font = 0;
+	SDL_Color m_color = { 255, 255, 255 };
+
+	void refresh();
 };

--- a/Source/Engine.cpp
+++ b/Source/Engine.cpp
@@ -1,7 +1,7 @@
 #define _CRT_SECURE_NO_WARNINGS
 
 #include <SDL.h>
-#include <SDL2/SDL_ttf.h>
+#include <SDL_ttf.h>
 #include <stdio.h>
 #include <iostream>
 #include <stdlib.h>
@@ -13,7 +13,6 @@
 #include <Helpers.h>
 #include <Engine.h>
 #include <Quaternion.h>
-
 #include <UI/UIObjects.h>
 
 RotationMatrix Camera::getRotationMatrix() {
@@ -187,9 +186,9 @@ void Engine::run() {
 	TTF_Font* mono = TTF_OpenFont("./Assets/FreeMono.ttf", 15);
 
 	UIText text;
+	text.setRenderer(renderer);
 	text.setFont(mono);
 	text.setPosition(10, 10);
-	text.setColor({255, 255, 255});
 
 	while (isRunning) {
 		lastStartTime = SDL_GetTicks();
@@ -220,9 +219,9 @@ void Engine::run() {
 
 
 		// Delta DEBUG text
-		std::string deltaMessage = "Delta frames: " + std::to_string(delta);
+		std::string deltaMessage = "Draw time: " + std::to_string(delta) + "ms";
 		text.setValue(deltaMessage.c_str());
-		text.draw(renderer);
+		text.draw();
 		// End DEBUG text
 
 		SDL_RenderPresent(renderer);

--- a/Source/UI/UIObjects.cpp
+++ b/Source/UI/UIObjects.cpp
@@ -1,26 +1,57 @@
 #include <UI/UIObjects.h>
 
+UIObject::~UIObject() {
+	if (m_texture != NULL) {
+		SDL_DestroyTexture(m_texture);
+	}
+}
+
 void UIObject::setPosition(int x, int y) {
 	m_rect.x = x;
 	m_rect.y = y;
 }
 
+void UIObject::setRenderer(SDL_Renderer* renderer) {
+	this->renderer = renderer;
+	refresh();
+}
+
+void UIObject::setTextureFromSurface(SDL_Surface* surface) {
+	m_texture = SDL_CreateTextureFromSurface(renderer, surface);
+
+	SDL_FreeSurface(surface);
+}
+
 void UIText::setValue(const char* value) {
-	m_surface = TTF_RenderText_Solid(m_font, value, m_color);
 	m_value = value;
-	TTF_SizeText(m_font, m_value, &m_rect.w, &m_rect.h);
+	refresh();
 }
 
 void UIText::setColor(const SDL_Color &color) {
 	m_color = color;
+	refresh();
 }
 
 void UIText::setFont(TTF_Font* font) {
 	m_font = font;
+	refresh();
 }
 
-void UIText::draw(SDL_Renderer* renderer) {
-	m_texture = SDL_CreateTextureFromSurface(renderer, m_surface);
-	SDL_RenderCopy(renderer, m_texture, NULL, &m_rect);
+void UIText::refresh() {
+	if (renderer != NULL && m_font != NULL && m_value != NULL) {
+		if (m_texture != NULL) {
+			SDL_DestroyTexture(m_texture);
+		}
+
+		SDL_Surface* m_surface = TTF_RenderText_Solid(m_font, m_value, m_color);
+
+		TTF_SizeText(m_font, m_value, &m_rect.w, &m_rect.h);
+		setTextureFromSurface(m_surface);
+	}
 }
 
+void UIText::draw() {
+	if (m_texture != NULL) {
+		SDL_RenderCopy(renderer, m_texture, NULL, &m_rect);
+	}
+}

--- a/cmake-modules/FindSDL2.cmake
+++ b/cmake-modules/FindSDL2.cmake
@@ -73,7 +73,7 @@ SET(SDL2_SEARCH_PATHS
   /opt/local # DarwinPorts
   /opt/csw # Blastwave
   /opt
-  ${SDL2_PATH}
+  C:/mingw-dev/SDL2
 )
 
 FIND_PATH(SDL2_INCLUDE_DIR SDL.h

--- a/cmake-modules/FindSDL2TTF.cmake
+++ b/cmake-modules/FindSDL2TTF.cmake
@@ -74,6 +74,7 @@ SET(SDL2TTF_SEARCH_PATHS
 	/opt/local # DarwinPorts
 	/opt/csw # Blastwave
 	/opt
+	C:/mingw-dev/SDL2_ttf
 )
 
 FIND_PATH(SDL2TTF_INCLUDE_DIR SDL_ttf.h


### PR DESCRIPTION
I decided to change the design of `UIObject`/`UIText` just enough to support setting an `SDL_Renderer*` target upfront and allowing textures to be re-created from a temporary `SDL_Surface` and cached upon changing options, rather than creating the texture again on each draw (although this may happen if an option is changed every frame - but it shouldn't be the default). `UIObject` subclasses must implement a `refresh` function for re-creating the new cached texture. Ideally, these subclasses should `refresh` upon any options being updated. Since we want to be able to update options in any order, `refresh` implementations should check to see that all necessary options are set using `!= NULL` checks or similar.

I also fixed some memory leaks by making sure the temporary surface is freed after caching the new texture, and also by destroying the existing texture prior to updating. `UIObject` also has a destructor which calls `SDL_DestroyTexture` a final time, if it is `!= NULL`.

To make `UIObject`s close in behavior to `Object`s, we will at some point want to be able to add them to the `Engine` (see `main.cpp`), which will then call `setRenderer` with its own internal instance.

**Note**: In order to test these changes out, I had to change the `SDL2/SDL_ttf.h` include to `SDL_ttf.h`. CMake might be determining different include paths for us based on our systems.