### PR TITLE
Hidden surface removal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,11 +30,12 @@ set(SOURCE_FILES
     # Engine (Headers)
     Library/Objects.h
     Library/Types.h
-    Library/Graphics/Rasterizer.h
     Library/Engine.h
     Library/Quaternion.h
     Library/Loaders/Loader.h
     Library/Loaders/ObjLoader.h
+    Library/Graphics/Rasterizer.h
+    Library/Graphics/RasterQueue.h
 
     # -- CPP Files --
 
@@ -45,11 +46,12 @@ set(SOURCE_FILES
     # Engine (CPP Files)
     Source/Objects.cpp
     Source/Types.cpp
-    Source/Graphics/Rasterizer.cpp
     Source/Engine.cpp
     Source/Quaternion.cpp
     Source/Loaders/Loader.cpp
     Source/Loaders/ObjLoader.cpp
+    Source/Graphics/Rasterizer.cpp
+    Source/Graphics/RasterQueue.cpp
 )
 
 add_executable(${EXECUTABLE_NAME} ${SOURCE_FILES})

--- a/Library/Engine.h
+++ b/Library/Engine.h
@@ -13,7 +13,8 @@ enum Flags : Uint32 {
 	DEBUG_DRAWTIME = 1 << 0,
 	SHOW_WIREFRAME = 1 << 1,
 	FLAT_SHADING = 1 << 2,
-	PIXEL_FILTER = 1 << 3
+	PIXEL_FILTER = 1 << 3,
+	REMOVE_OCCLUDED_SURFACES = 1 << 4
 };
 
 struct Camera {
@@ -53,14 +54,14 @@ class Engine {
 		Movement movement;
 		bool isRunning = false;
 		constexpr static int MOVEMENT_SPEED = 5;
-		constexpr static int ZONE_SIZE = 500;
+		constexpr static int ZONE_RANGE = 250;
 		Uint32 flags = 0;
 
 		int width;
 		int height;
 		void delay(int ms);
 		void drawScene();
-		void fillRasterQueue();
+		void drawTriangle(Triangle& triangle);
 		int getPolygonCount();
 		void handleEvent(const SDL_Event& event);
 		void handleKeyDown(const SDL_Keycode& code);

--- a/Library/Engine.h
+++ b/Library/Engine.h
@@ -3,10 +3,11 @@
 #include <SDL.h>
 #include <math.h>
 #include <vector>
-#include <Graphics/Rasterizer.h>
 #include <Objects.h>
 #include <Types.h>
 #include <UI/UI.h>
+#include <Graphics/Rasterizer.h>
+#include <Graphics/RasterQueue.h>
 
 enum Flags : Uint32 {
 	DEBUG_DRAWTIME = 1 << 0,
@@ -16,11 +17,12 @@ enum Flags : Uint32 {
 };
 
 struct Camera {
+	constexpr static float MAX_PITCH = 89 * M_PI / 180;
 	Vec3 position = { 0, 100, 0 };
 	float pitch = 0.0f;
 	float yaw = 0.0f;
 	int fov = 90;
-	constexpr static float MAX_PITCH = 89 * M_PI / 180;
+
 	RotationMatrix getRotationMatrix();
 };
 
@@ -36,7 +38,6 @@ class Engine {
 
 		void addObject(Object* object);
 		void addUIObject(UIObject* uiObject);
-		void draw();
 		void run();
 
 	private:
@@ -44,21 +45,27 @@ class Engine {
 		SDL_Renderer* renderer;
 		std::vector<Object*> objects;
 		Rasterizer* rasterizer;
+		RasterQueue* rasterQueue;
 		UI* ui;
 
 		Camera camera;
 		Vec3 velocity;
 		Movement movement;
+		bool isRunning = false;
 		constexpr static int MOVEMENT_SPEED = 5;
+		constexpr static int ZONE_SIZE = 500;
 		Uint32 flags = 0;
 
 		int width;
 		int height;
 		void delay(int ms);
+		void drawScene();
+		void fillRasterQueue();
 		int getPolygonCount();
 		void handleEvent(const SDL_Event& event);
 		void handleKeyDown(const SDL_Keycode& code);
 		void handleKeyUp(const SDL_Keycode& code);
 		void handleMouseMotionEvent(const SDL_MouseMotionEvent& event);
+		void update();
 		void updateMovement();
 };

--- a/Library/Graphics/RasterQueue.h
+++ b/Library/Graphics/RasterQueue.h
@@ -6,16 +6,36 @@
 
 typedef std::vector<Triangle> Zone;
 
+struct Cover {
+	Coordinate c1;
+	Coordinate c2;
+	Coordinate c3;
+	int zone;
+};
+
 class RasterQueue {
 public:
-	bool isEmpty();
-	void queue(Triangle triangle, int zoneIndex);
+	RasterQueue(int width, int height);
+
+	void addTriangle(Triangle triangle, int zoneIndex);
+	int DEBUG_getTotalCovers();
 	Triangle* next();
 
 private:
 	constexpr static int MAX_ZONES = 50;
+	constexpr static int MIN_COVER_SIZE = 150;
 	int currentZoneIndex = 0;
 	int highestZoneIndex = 0;
 	int currentElementIndex = 0;
+	int width;
+	int height;
 	Zone zones[RasterQueue::MAX_ZONES];
+	std::vector<Cover> covers;
+
+	void addCover(Triangle& triangle, int zone);
+	bool isTriangleCoverable(Triangle& triangle);
+	bool isTriangleVisible(Triangle& triangle);
+	bool isTriangleOccluded(Triangle& triangle, const Cover& cover);
+	bool isPointWithinEdge(int x, int y, int ex1, int ey1, int ex2, int ey2);
+	void reset();
 };

--- a/Library/Graphics/RasterQueue.h
+++ b/Library/Graphics/RasterQueue.h
@@ -4,8 +4,21 @@
 #include <optional>
 #include <Types.h>
 
+/**
+ * Zone
+ * ----
+ *
+ * A lineup of Triangle objects corresponding to a given zone.
+ */
 typedef std::vector<Triangle> Zone;
 
+/**
+ * Cover
+ * -----
+ *
+ * Represents the screen coverage of larger Triangles which
+ * are capable of occluding others behind them.
+ */
 struct Cover {
 	Coordinate c1;
 	Coordinate c2;
@@ -13,6 +26,14 @@ struct Cover {
 	int zone;
 };
 
+/**
+ * RasterQueue
+ * -----------
+ *
+ * Provides a mechanism for receiving and storing Triangles by 'zone'
+ * before they are drawn, and dispensing them in zone-order, also
+ * filtering out triangles occluded by larger, closer ones.
+ */
 class RasterQueue {
 public:
 	RasterQueue(int width, int height);
@@ -26,8 +47,8 @@ private:
 	int currentZoneIndex = 0;
 	int highestZoneIndex = 0;
 	int currentElementIndex = 0;
-	int width;
-	int height;
+	int rasterWidth;
+	int rasterHeight;
 	Zone zones[RasterQueue::MAX_ZONES];
 	std::vector<Cover> covers;
 

--- a/Library/Graphics/RasterQueue.h
+++ b/Library/Graphics/RasterQueue.h
@@ -18,7 +18,6 @@ public:
 	RasterQueue(int width, int height);
 
 	void addTriangle(Triangle triangle, int zoneIndex);
-	int DEBUG_getTotalCovers();
 	Triangle* next();
 
 private:
@@ -32,10 +31,11 @@ private:
 	Zone zones[RasterQueue::MAX_ZONES];
 	std::vector<Cover> covers;
 
-	void addCover(Triangle& triangle, int zone);
-	bool isTriangleCoverable(Triangle& triangle);
-	bool isTriangleVisible(Triangle& triangle);
-	bool isTriangleOccluded(Triangle& triangle, const Cover& cover);
+	void addCover(const Triangle& triangle, int zone);
 	bool isPointWithinEdge(int x, int y, int ex1, int ey1, int ex2, int ey2);
+	bool isTriangleCoverable(const Triangle& triangle);
+	bool isTriangleNearby(const Triangle& triangle, const Cover& cover);
+	bool isTriangleOccluded(const Triangle& triangle, const Cover& cover);
+	bool isTriangleVisible(Triangle& triangle);
 	void reset();
 };

--- a/Library/Graphics/RasterQueue.h
+++ b/Library/Graphics/RasterQueue.h
@@ -57,6 +57,6 @@ private:
 	bool isTriangleCoverable(const Triangle& triangle);
 	bool isTriangleNearby(const Triangle& triangle, const Cover& cover);
 	bool isTriangleOccluded(const Triangle& triangle, const Cover& cover);
-	bool isTriangleVisible(Triangle& triangle);
+	bool isTriangleVisible(const Triangle& triangle);
 	void reset();
 };

--- a/Library/Graphics/RasterQueue.h
+++ b/Library/Graphics/RasterQueue.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <vector>
+#include <optional>
+#include <Types.h>
+
+typedef std::vector<Triangle> Zone;
+
+class RasterQueue {
+public:
+	bool isEmpty();
+	void queue(Triangle triangle, int zoneIndex);
+	Triangle* next();
+
+private:
+	constexpr static int MAX_ZONES = 50;
+	int currentZoneIndex = 0;
+	int highestZoneIndex = 0;
+	int currentElementIndex = 0;
+	Zone zones[RasterQueue::MAX_ZONES];
+};

--- a/Library/Types.h
+++ b/Library/Types.h
@@ -73,6 +73,7 @@ struct Vertex3d : Colorable {
 struct Triangle {
 	Vertex2d vertices[3];
 
+	float averageDepth() const;
 	void createVertex(int index, int x, int y, int depth, const Color& color);
 };
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A software 3D rendering engine, written as an educational exercise.
 
 ### Features
 
+* On-screen debug stats
 * Light sources
 * Texture mapping
 * Parallelization

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ A software 3D rendering engine, written as an educational exercise.
 
 ### Features
 
-* Improved hidden surface removal
 * Light sources
 * Texture mapping
 * Parallelization

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A software 3D rendering engine, written as an educational exercise.
 
 ### Features
 
+* Swappable "Benchmark" scenarios
 * On-screen debug stats
 * Light sources
 * Texture mapping

--- a/Source/Engine.cpp
+++ b/Source/Engine.cpp
@@ -117,8 +117,7 @@ void Engine::drawScene() {
 			}
 
 			Triangle triangle;
-			bool isInView = false;
-			int depthSum = 0;
+			bool isInFront = false;
 
 			for (int i = 0; i < 3; i++) {
 				Vec3 vertex = rotationMatrix * (relativeObjectPosition + polygon.vertices[i]->vector);
@@ -128,18 +127,16 @@ void Engine::drawScene() {
 				int y = (int)(fovScalar * -unitVertex.y / (1 + distortionCorrectedZ) + midpointY);
 				int depth = (int)vertex.z;
 
-				depthSum += depth;
-
-				if (!isInView && depth > 0) {
-					isInView = true;
+				if (!isInFront && depth > 0) {
+					isInFront = true;
 				}
 
 				triangle.createVertex(i, x, y, depth, polygon.vertices[i]->color);
 			}
 
-			if (isInView) {
+			if (isInFront) {
 				if (shouldRemoveOccludedSurfaces) {
-					int zone = (int)((depthSum / 3) / Engine::ZONE_RANGE);
+					int zone = (int)(triangle.averageDepth() / Engine::ZONE_RANGE);
 
 					rasterQueue->addTriangle(triangle, zone);
 				} else {

--- a/Source/Graphics/RasterQueue.cpp
+++ b/Source/Graphics/RasterQueue.cpp
@@ -3,12 +3,16 @@
 #include <Helpers.h>
 #include <Graphics/RasterQueue.h>
 
+/**
+ * RasterQueue
+ * -----------
+ */
 RasterQueue::RasterQueue(int width, int height) {
 	this->width = width;
 	this->height = height;
 }
 
-void RasterQueue::addCover(Triangle& triangle, int zone) {
+void RasterQueue::addCover(const Triangle& triangle, int zone) {
 	covers.push_back({
 		triangle.vertices[0].coordinate,
 		triangle.vertices[1].coordinate,
@@ -31,36 +35,14 @@ void RasterQueue::addTriangle(Triangle triangle, int zoneIndex) {
 	zones[zoneIndex].push_back(triangle);
 }
 
-int RasterQueue::DEBUG_getTotalCovers() {
-	return covers.size();
-}
-
 bool RasterQueue::isPointWithinEdge(int x, int y, int ex1, int ey1, int ex2, int ey2) {
-	if (ex1 == ex2) {
-		// Trivial case #1: For vertical edges, we can simply
-		// check whether the point x is > the edge x for downward
-		// lines or < the edge x for upward lines.
-		return ey2 > ey1 ? (x > ex1) : (x < ex1);
-	} else if (ey1 == ey2) {
-		// Trivial case #2: For horizontal edges, we can simply
-		// check whether the point y is < the edge y for rightward
-		// lines or > the edge y for leftward lines.
-		return ex2 > ex1 ? (y < ey1) : (y > ey1);
-	} else {
-		// Nontrivial case: we have to determine the edge slope
-		// and check whether the point is 'inside' or 'outside'.
-		float slope = (float)(ey2 - ey1) / (ex2 - ex1);
-		bool isDownwardEdge = ey2 > ey1;
-		int edgeXAtPoint = ex1 + (int)((y - ey1) / slope);
-
-		return isDownwardEdge ? (x > edgeXAtPoint) : (x < edgeXAtPoint);
-	}
+	return ((x - ex1) * (ey2 - ey1) - (y - ey1) * (ex2 - ex1)) > 0;
 }
 
-bool RasterQueue::isTriangleCoverable(Triangle& triangle) {
-	Coordinate* c1 = &triangle.vertices[0].coordinate;
-	Coordinate* c2 = &triangle.vertices[1].coordinate;
-	Coordinate* c3 = &triangle.vertices[2].coordinate;
+bool RasterQueue::isTriangleCoverable(const Triangle& triangle) {
+	const Coordinate* c1 = &triangle.vertices[0].coordinate;
+	const Coordinate* c2 = &triangle.vertices[1].coordinate;
+	const Coordinate* c3 = &triangle.vertices[2].coordinate;
 
 	int minX = std::min(c1->x, std::min(c2->x, c3->x));
 	int maxX = std::max(c1->x, std::max(c2->x, c3->x));
@@ -83,9 +65,9 @@ bool RasterQueue::isTriangleCoverable(Triangle& triangle) {
 /**
  * Determines whether a Triangle is occluded by a Cover.
  */
-bool RasterQueue::isTriangleOccluded(Triangle& triangle, const Cover& cover) {
+bool RasterQueue::isTriangleOccluded(const Triangle& triangle, const Cover& cover) {
 	for (int i = 0; i < 3; i++) {
-		Coordinate* v = &triangle.vertices[i].coordinate;
+		const Coordinate* v = &triangle.vertices[i].coordinate;
 
 		// To determine whether a triangle T is completely covered by
 		// another triangle T*, we have to check T's vertices against

--- a/Source/Graphics/RasterQueue.cpp
+++ b/Source/Graphics/RasterQueue.cpp
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <optional>
 #include <Helpers.h>
 #include <Graphics/RasterQueue.h>
 
@@ -8,8 +7,8 @@
  * -----------
  */
 RasterQueue::RasterQueue(int width, int height) {
-	this->width = width;
-	this->height = height;
+	this->rasterWidth = width;
+	this->rasterHeight = height;
 }
 
 void RasterQueue::addCover(const Triangle& triangle, int zone) {
@@ -57,8 +56,8 @@ bool RasterQueue::isTriangleCoverable(const Triangle& triangle) {
 		(maxY - minY) > MIN_COVER_SIZE &&
 		// Ensure that it extends far enough into the screen
 		// that distant triangles are likely to be covered by it
-		(minX < (width - MIN_COVER_SIZE) && maxX > MIN_COVER_SIZE) &&
-		(minY < (height - MIN_COVER_SIZE) && maxY > MIN_COVER_SIZE)
+		(minX < (rasterWidth - MIN_COVER_SIZE) && maxX > MIN_COVER_SIZE) &&
+		(minY < (rasterHeight - MIN_COVER_SIZE) && maxY > MIN_COVER_SIZE)
 	);
 }
 

--- a/Source/Graphics/RasterQueue.cpp
+++ b/Source/Graphics/RasterQueue.cpp
@@ -1,22 +1,127 @@
 #include <algorithm>
 #include <optional>
-#include <Graphics/RasterQueue.h>
 #include <Helpers.h>
+#include <Graphics/RasterQueue.h>
 
-void RasterQueue::queue(Triangle triangle, int zoneIndex) {
+RasterQueue::RasterQueue(int width, int height) {
+	this->width = width;
+	this->height = height;
+}
+
+void RasterQueue::addCover(Triangle& triangle, int zone) {
+	covers.push_back({
+		triangle.vertices[0].coordinate,
+		triangle.vertices[1].coordinate,
+		triangle.vertices[2].coordinate,
+		zone
+	});
+}
+
+void RasterQueue::addTriangle(Triangle triangle, int zoneIndex) {
 	zoneIndex = clamp(zoneIndex, 0, RasterQueue::MAX_ZONES - 1);
 
 	if (zoneIndex > highestZoneIndex) {
 		highestZoneIndex = zoneIndex;
 	}
 
+	if (isTriangleCoverable(triangle)) {
+		addCover(triangle, zoneIndex);
+	}
+
 	zones[zoneIndex].push_back(triangle);
+}
+
+int RasterQueue::DEBUG_getTotalCovers() {
+	return covers.size();
+}
+
+bool RasterQueue::isPointWithinEdge(int x, int y, int ex1, int ey1, int ex2, int ey2) {
+	if (ex1 == ex2) {
+		// Trivial case #1: For vertical edges, we can simply
+		// check whether the point x is > the edge x for downward
+		// lines or < the edge x for upward lines.
+		return ey2 > ey1 ? (x > ex1) : (x < ex1);
+	} else if (ey1 == ey2) {
+		// Trivial case #2: For horizontal edges, we can simply
+		// check whether the point y is < the edge y for rightward
+		// lines or > the edge y for leftward lines.
+		return ex2 > ex1 ? (y < ey1) : (y > ey1);
+	} else {
+		// Nontrivial case: we have to determine the edge slope
+		// and check whether the point is 'inside' or 'outside'.
+		float slope = (float)(ey2 - ey1) / (ex2 - ex1);
+		bool isDownwardEdge = ey2 > ey1;
+		int edgeXAtPoint = ex1 + (int)((y - ey1) / slope);
+
+		return isDownwardEdge ? (x > edgeXAtPoint) : (x < edgeXAtPoint);
+	}
+}
+
+bool RasterQueue::isTriangleCoverable(Triangle& triangle) {
+	Coordinate* c1 = &triangle.vertices[0].coordinate;
+	Coordinate* c2 = &triangle.vertices[1].coordinate;
+	Coordinate* c3 = &triangle.vertices[2].coordinate;
+
+	int minX = std::min(c1->x, std::min(c2->x, c3->x));
+	int maxX = std::max(c1->x, std::max(c2->x, c3->x));
+
+	int minY = std::min(c1->y, std::min(c2->y, c3->y));
+	int maxY = std::max(c1->y, std::max(c2->y, c3->y));
+
+	return (
+		// Ensure that the triangle is over the minimum
+		// cover size along both axes
+		(maxX - minX) > MIN_COVER_SIZE &&
+		(maxY - minY) > MIN_COVER_SIZE &&
+		// Ensure that it extends far enough into the screen
+		// that distant triangles are likely to be covered by it
+		(minX < (width - MIN_COVER_SIZE) && maxX > MIN_COVER_SIZE) &&
+		(minY < (height - MIN_COVER_SIZE) && maxY > MIN_COVER_SIZE)
+	);
+}
+
+/**
+ * Determines whether a Triangle is occluded by a Cover.
+ */
+bool RasterQueue::isTriangleOccluded(Triangle& triangle, const Cover& cover) {
+	for (int i = 0; i < 3; i++) {
+		Coordinate* v = &triangle.vertices[i].coordinate;
+
+		// To determine whether a triangle T is completely covered by
+		// another triangle T*, we have to check T's vertices against
+		// T*'s edges. Whereas in world space polygon vertices are
+		// oriented counter-clockwise, in raster space they are oriented
+		// clockwise due to the inversion of the y-axis. In order to
+		// correctly determine which 'side' of T*'s edges T's vertices
+		// lie on, we need to check the edges along T*v1 -> T*v3,
+		// T*v3 -> T*v2, and T*v2 -> T*v1.
+		if (
+			!isPointWithinEdge(v->x, v->y, cover.c1.x, cover.c1.y, cover.c3.x, cover.c3.y) ||
+			!isPointWithinEdge(v->x, v->y, cover.c3.x, cover.c3.y, cover.c2.x, cover.c2.y) ||
+			!isPointWithinEdge(v->x, v->y, cover.c2.x, cover.c2.y, cover.c1.x, cover.c1.y)
+		) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool RasterQueue::isTriangleVisible(Triangle& triangle) {
+	for (const auto &cover : covers) {
+		if (cover.zone < currentZoneIndex && isTriangleOccluded(triangle, cover)) {
+			return false;
+		}
+	}
+
+	return true;
 }
 
 Triangle* RasterQueue::next() {
 	Zone* currentZone = &zones[currentZoneIndex];
+	bool isEndOfZone = currentElementIndex >= currentZone->size() || currentZone->size() == 0;
 
-	if (currentElementIndex >= currentZone->size() || currentZone->size() == 0) {
+	if (isEndOfZone) {
 		currentZone->clear();
 
 		currentElementIndex = 0;
@@ -26,12 +131,20 @@ Triangle* RasterQueue::next() {
 
 			return next();
 		} else {
-			currentZoneIndex = 0;
-			highestZoneIndex = 0;
+			reset();
 
 			return NULL;
 		}
 	} else {
-		return &currentZone->at(currentElementIndex++);
+		Triangle* triangle = &currentZone->at(currentElementIndex++);
+
+		return isTriangleVisible(*triangle) ? triangle : next();
 	}
+}
+
+void RasterQueue::reset() {
+	currentZoneIndex = 0;
+	highestZoneIndex = 0;
+
+	covers.clear();
 }

--- a/Source/Graphics/RasterQueue.cpp
+++ b/Source/Graphics/RasterQueue.cpp
@@ -1,0 +1,37 @@
+#include <algorithm>
+#include <optional>
+#include <Graphics/RasterQueue.h>
+#include <Helpers.h>
+
+void RasterQueue::queue(Triangle triangle, int zoneIndex) {
+	zoneIndex = clamp(zoneIndex, 0, RasterQueue::MAX_ZONES - 1);
+
+	if (zoneIndex > highestZoneIndex) {
+		highestZoneIndex = zoneIndex;
+	}
+
+	zones[zoneIndex].push_back(triangle);
+}
+
+Triangle* RasterQueue::next() {
+	Zone* currentZone = &zones[currentZoneIndex];
+
+	if (currentElementIndex >= currentZone->size() || currentZone->size() == 0) {
+		currentZone->clear();
+
+		currentElementIndex = 0;
+
+		if (currentZoneIndex < highestZoneIndex) {
+			currentZoneIndex++;
+
+			return next();
+		} else {
+			currentZoneIndex = 0;
+			highestZoneIndex = 0;
+
+			return NULL;
+		}
+	} else {
+		return &currentZone->at(currentElementIndex++);
+	}
+}

--- a/Source/Graphics/RasterQueue.cpp
+++ b/Source/Graphics/RasterQueue.cpp
@@ -88,7 +88,7 @@ bool RasterQueue::isTriangleOccluded(const Triangle& triangle, const Cover& cove
 	return true;
 }
 
-bool RasterQueue::isTriangleVisible(Triangle& triangle) {
+bool RasterQueue::isTriangleVisible(const Triangle& triangle) {
 	for (const auto &cover : covers) {
 		if (cover.zone < currentZoneIndex && isTriangleOccluded(triangle, cover)) {
 			return false;

--- a/Source/Types.cpp
+++ b/Source/Types.cpp
@@ -103,6 +103,10 @@ Vec3 Vec3::operator -(const Vec3& vector) const {
  * Triangle
  * --------
  */
+float Triangle::averageDepth() const {
+	return (vertices[0].depth + vertices[1].depth + vertices[2].depth) / 3;
+}
+
 void Triangle::createVertex(int index, int x, int y, int depth, const Color& color) {
 	Vertex2d vertex;
 

--- a/Source/Types.cpp
+++ b/Source/Types.cpp
@@ -2,6 +2,10 @@
 #include <cmath>
 #include <Types.h>
 
+/**
+ * RotationMatrix
+ * --------------
+ */
 RotationMatrix RotationMatrix::operator *(const RotationMatrix& rm) const {
 	return {
 		m11 * rm.m11 + m12 * rm.m21 + m13 * rm.m31, m11 * rm.m12 + m12 * rm.m22 + m13 * rm.m32, m11 * rm.m13 + m12 * rm.m23 + m13 * rm.m33,
@@ -33,6 +37,10 @@ Vec3 RotationMatrix::operator *(const Vec3& v) const {
 	};
 }
 
+/**
+ * Vec3
+ * ----
+ */
 Vec3::Vec3() {}
 
 Vec3::Vec3(float x, float y, float z) {
@@ -91,6 +99,10 @@ Vec3 Vec3::operator -(const Vec3& vector) const {
 	};
 }
 
+/**
+ * Triangle
+ * --------
+ */
 void Triangle::createVertex(int index, int x, int y, int depth, const Color& color) {
 	Vertex2d vertex;
 
@@ -102,6 +114,10 @@ void Triangle::createVertex(int index, int x, int y, int depth, const Color& col
 	vertices[index] = vertex;
 }
 
+/**
+ * Polygon
+ * -------
+ */
 void Polygon::bindVertex(int index, Vertex3d* vertex) {
 	vertices[index] = vertex;
 }

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -6,7 +6,7 @@ int width = 1200;
 int height = 720;
 
 int main(int argc, char* argv[]) {
-	Engine engine(width, height, DEBUG_DRAWTIME);
+	Engine* engine = new Engine(width, height, DEBUG_DRAWTIME);
 
 	TTF_Font* mono = TTF_OpenFont("./Assets/FreeMono.ttf", 15);
 
@@ -15,10 +15,10 @@ int main(int argc, char* argv[]) {
 	text.setFont(mono);
 	text.setPosition(10, 10);
 
-	Mesh mesh(100, 40, 50);
+	Mesh* mesh = new Mesh(100, 40, 50);
 
-	mesh.position = { -1000, 0, -1000 };
-	mesh.setColor(0, 255, 0);
+	mesh->position = { -1000, 0, -1000 };
+	mesh->setColor(0, 255, 0);
 
 	Cube cube(100);
 	Cube cube2(50);
@@ -38,15 +38,18 @@ int main(int argc, char* argv[]) {
 	icosahedron.position = { 0, 50, 2000 };
 	icosahedron.scale(200);
 
-	engine.addUIObject(&text);
-	engine.addObject(&mesh);
-	engine.addObject(&cube);
-	engine.addObject(&cube2);
-	engine.addObject(&cube3);
-	engine.addObject(&icosahedron);
-	engine.run();
+	engine->addUIObject(&text);
+	engine->addObject(mesh);
+	engine->addObject(&cube);
+	engine->addObject(&cube2);
+	engine->addObject(&cube3);
+	engine->addObject(&icosahedron);
+	engine->run();
 
 	TTF_CloseFont(mono);
+
+	delete mesh;
+	delete engine;
 
 	return 0;
 }

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -6,7 +6,7 @@ int width = 1200;
 int height = 720;
 
 int main(int argc, char* argv[]) {
-	Engine* engine = new Engine(width, height, DEBUG_DRAWTIME);
+	Engine* engine = new Engine(width, height, REMOVE_OCCLUDED_SURFACES | DEBUG_DRAWTIME);
 
 	TTF_Font* mono = TTF_OpenFont("./Assets/FreeMono.ttf", 15);
 


### PR DESCRIPTION
This adds support for partial occlusion culling against distant triangles behind larger, closer ones.

Architecturally this works as follows: rather than projecting and rasterizing triangles in the order that they're stored in the world, we instead "zone" them by distance and rasterize each zone incrementally. **Zones** can also be thought of as triangles grouped within concentric circle "chunks" extending outward from the player. More efficient than sorting, quite inexpensive to compute on top of everything else, and helps ensure that the z-buffer limits per-pixel overdraws no matter where you are in the world.

Occlusion culling follows naturally from this first technique; with zones we can automatically discern more about which triangles sit behind others without the need to sort them. Triangles larger than a given threshold can be designated as **Cover** triangles, capable of occluding others behind them. Only triangles in later zones than a cover triangle have their points checked against its edges to determine whether they're being occluded from view.

Since this change isn't without lateral computational expense, I've added a new `REMOVE_OCCLUDED_SURFACES` flag to `Engine` to allow the mechanism to be enabled or disabled freely. Soon I'll set up some benchmark scenarios to allow us to better test effects on performance as we proceed to rudimentary lighting and texture mapping.

---

Some wireframe examples illustrating the occlusion culling behavior:

![culling2](https://user-images.githubusercontent.com/9344964/52163102-0d873400-26a3-11e9-9b72-1aa6709d90fa.png)

Note that the triangles on the boundary of the cover triangle clip slightly into its edge. We aren't *truncating* triangles on this boundary; we're only using the boundaries to determine which triangles are *completely* occluded, and not drawing them at all.

---

![culling3](https://user-images.githubusercontent.com/9344964/52163123-55a65680-26a3-11e9-88e9-60abede736eb.png)

Note the strand of triangles "walking" up the boundary between these two cover triangles. What we're actually seeing here are triangles not completely occluded by either one individually, but only both together. Initially I believed this to be a design oversight, and proceeded to "fix" the problem by checking to see whether *any* of a triangle's points were outside of *all* cover triangles before drawing them. **This would not work**: we might have a triangle with its three vertices inside two cover triangles separated by visible space.