### PR TITLE
Optional static lights/objects + light caching

### DIFF
--- a/Demo/Levels/Default.cpp
+++ b/Demo/Levels/Default.cpp
@@ -9,6 +9,7 @@ void Default::load() {
 	Mesh* mesh = new Mesh(100, 40, 50);
 
 	mesh->position = { -1000, 0, -1000 };
+	mesh->isStatic = true;
 
 	Cube* cube = new Cube(100);
 	Cube* cube2 = new Cube(50);
@@ -18,6 +19,9 @@ void Default::load() {
 	cube->position = { -200, 200, 500 };
 	cube2->position = { 50, 150, 500 };
 	cube3->position = { 200, 100, 500 };
+	cube->isStatic = true;
+	cube2->isStatic = true;
+	cube3->isStatic = true;
 	oscillatingCube->position = { 0, 0, 1500 };
 
 	cube->rotate({ 0.5, 0.5, 0.5 });
@@ -29,6 +33,7 @@ void Default::load() {
 
 	icosahedron->position = { 0, 220, 2000 };
 	icosahedron->scale(200);
+	icosahedron->isStatic = true;
 
 	add(mesh);
 	add(cube);
@@ -40,15 +45,15 @@ void Default::load() {
 	Light* light = new Light();
 	light->setColor(0, 0, 255);
 	light->position = { 0, 100, 2000 };
-	light->spread = 1000;
+	light->range = 1000;
 
 	add("light", light);
 
-	settings.backgroundColor = { 25, 0, 50 };
-	settings.brightness = 0.2;
-	settings.ambientLightColor = { 255, 0, 100 };
+	settings.backgroundColor = { 50, 0, 75 };
+	settings.brightness = 0.3;
+	settings.ambientLightColor = { 255, 0, 200 };
 	settings.ambientLightVector = { 0, -1, 1 };
-	settings.ambientLightFactor = 0.3;
+	settings.ambientLightFactor = 0.5;
 }
 
 void Default::update(int dt, int runningTime) {

--- a/Demo/Levels/Garden.cpp
+++ b/Demo/Levels/Garden.cpp
@@ -22,6 +22,7 @@ void Garden::load() {
 		tree->setTexture(getTexture("tree-texture"));
 		tree->scale(100);
 		tree->rotateDeg({ 0, (float)(rand() % 360), 0 });
+		tree->isStatic = true;
 
 		add(tree);
 	}
@@ -33,12 +34,14 @@ void Garden::load() {
 
 		light->setColor(255, 50, 0);
 		light->position = { (float)(2000 - rand() % 4000), 50 + (float)(rand() % 200), (float)(5000 - rand() % 4000) };
-		light->spread = 500 + rand() % 700;
+		light->range = 500 + rand() % 700;
 		light->power = 1.5f;
+		light->isStatic = true;
 
 		cube->position.x = light->position.x;
 		cube->position.y = light->position.y;
 		cube->position.z = light->position.z;
+		cube->isStatic = true;
 
 		add(light);
 		add(cube);
@@ -46,7 +49,7 @@ void Garden::load() {
 
 	Light* movingLight = new Light();
 	movingLight->setColor({ 255, 50, 255 });
-	movingLight->spread = 750;
+	movingLight->range = 750;
 	movingLight->position.y = 300;
 	movingLight->power = 1.5f;
 
@@ -54,8 +57,9 @@ void Garden::load() {
 
 	Model* teapot = new Model(teapotObj);
 	teapot->setColor(255, 255, 255);
-	teapot->position = { -500, 10, 2000 };
+	teapot->position = { -1000, 10, 2000 };
 	teapot->scale(50);
+	teapot->isStatic = true;
 
 	add(teapot);
 
@@ -64,6 +68,8 @@ void Garden::load() {
 	mesh->position = { -2500, -40, 0 };
 	mesh->setTexture(getTexture("ground-texture"));
 	mesh->setTextureInterval(5, 5);
+	mesh->isStatic = true;
+
 	add(mesh);
 
 	settings.backgroundColor = { 0, 0, 0 };
@@ -72,6 +78,7 @@ void Garden::load() {
 	settings.ambientLightColor = { 0, 0, 255 };
 	settings.ambientLightVector = { 0, -0.1, 1 };
 	settings.ambientLightFactor = 1;
+	settings.hasStaticAmbientLight = true;
 }
 
 void Garden::update(int dt, int runningTime) {

--- a/Demo/Levels/LightTest.cpp
+++ b/Demo/Levels/LightTest.cpp
@@ -18,13 +18,18 @@ void LightTest::load() {
 
 	floorMesh->position = { 500, 0, 0 };
 	floorMesh->rotateDeg({ 0, -90, 0 });
+	floorMesh->isStatic = true;
+
 	leftWall->setColor(210, 210, 210);
 	leftWall->position = { -500, 0, 0 };
 	leftWall->rotateDeg({ 0, -90, 0 });
 	leftWall->rotateDeg({ 0, 0, -90 });
+	leftWall->isStatic = true;
+
 	rightWall->position = { 500, 500, 0 };
 	rightWall->rotateDeg({ 0, -90, 90 });
 	rightWall->setColor(210, 210, 210);
+	rightWall->isStatic = true;
 
 	add("wall", new TextureBuffer("./DemoAssets/wall.png"));
 
@@ -40,18 +45,25 @@ void LightTest::load() {
 	Model* icosahedron = new Model(icoObj);
 	icosahedron->position = { 0, 250, 500 };
 	icosahedron->scale(100);
+	icosahedron->isStatic = true;
 
 	add(icosahedron);
 
 	Cube* cube1 = new Cube(50);
 	Cube* cube2 = new Cube(70);
 	Cube* cube3 = new Cube(150);
+
 	cube1->position = { -200, 300, 1000 };
 	cube2->position = { 200, 150, 1800 };
 	cube3->position = { -150, 200, 2600 };
+
 	cube1->rotate({ -2.4, 0, -1.2 });
 	cube2->rotate({ 0, 1.5, 0.6 });
 	cube3->rotate({ 1.5, -1.8, 1.6 });
+
+	cube1->isStatic = true;
+	cube2->isStatic = true;
+	cube3->isStatic = true;
 
 	add("cat", new TextureBuffer("./DemoAssets/cat.png"));
 	add("opossum", new TextureBuffer("./DemoAssets/opossum.png"));
@@ -66,30 +78,33 @@ void LightTest::load() {
 	add(cube2);
 	add(cube3);
 
-	Light* light = new Light();
-	light->position = { 0, 300, 500 };
-	light->setColor(255, 220, 50);
-	light->spread = 1000;
+	Light* yellowLight = new Light();
+	yellowLight->position = { 0, 300, 500 };
+	yellowLight->setColor(255, 220, 50);
+	yellowLight->range = 1000;
 
 	Light* light2 = new Light();
 	light2->position = { 200, 200, 1500 };
 	light2->setColor(255, 0, 0);
-	light2->spread = 700;
+	light2->range = 700;
 	light2->power = 1.5f;
+	light2->isStatic = true;
 
 	Light* light3 = new Light();
 	light3->position = { -200, 150, 2200 };
 	light3->setColor(0, 0, 255);
-	light3->spread = 600;
+	light3->range = 600;
 	light3->power = 1.5f;
+	light3->isStatic = true;
 
 	Light* light4 = new Light();
 	light4->position = { 300, 150, 2900 };
 	light4->setColor(0, 255, 0);
-	light4->spread = 800;
+	light4->range = 800;
 	light4->power = 1.5f;
+	light4->isStatic = true;
 
-	add("yellowLight", light);
+	add("yellowLight", yellowLight);
 	add(light2);
 	add(light3);
 	add(light4);
@@ -99,6 +114,7 @@ void LightTest::load() {
 	settings.ambientLightColor = { 0, 0, 255 };
 	settings.ambientLightVector = { 0, -0.5, 1 };
 	settings.ambientLightFactor = 0.2;
+	settings.hasStaticAmbientLight = true;
 }
 
 void LightTest::update(int dt, int runningTime) {

--- a/Demo/Levels/StressTest.cpp
+++ b/Demo/Levels/StressTest.cpp
@@ -11,6 +11,7 @@ void StressTest::load() {
 
 	Mesh* mesh = new Mesh(400, 80, 50);
 	mesh->position = { -2000, 0, 0 };
+	mesh->isStatic = true;
 
 	add(mesh);
 
@@ -20,9 +21,11 @@ void StressTest::load() {
 
 		icosahedron->position = { -1000, 250, 500.0f + (i * 1000) };
 		icosahedron->scale(200);
+		icosahedron->isStatic = true;
 
 		cube->position = { 500, 180, 500.0f + (i * 500) };
 		cube->rotate({ 0, i * 0.5f, -i * 0.5f });
+		cube->isStatic = true;
 
 		add(icosahedron);
 		add(cube);
@@ -35,8 +38,9 @@ void StressTest::load() {
 		float z = i * 1200;
 
 		light->position = { x, y, z };
-		light->setColor(255, 0, 0);
-		light->spread = 900;
+		light->setColor(255, 200, 100);
+		light->range = 900;
+		light->isStatic = true;
 
 		add(light);
 	}
@@ -47,5 +51,6 @@ void StressTest::load() {
 	settings.ambientLightVector = { 0, -1, 1 };
 	settings.ambientLightFactor = 0.2;
 	settings.backgroundColor = { 0, 100, 200 };
+	settings.hasStaticAmbientLight = true;
 }
 

--- a/Library/Engine.h
+++ b/Library/Engine.h
@@ -84,6 +84,7 @@ public:
 private:
 	constexpr static float NEAR_Z = 10.0f;
 	constexpr static int MOVEMENT_SPEED = 5;
+	constexpr static int AMBIENT_LIGHT_ID = 0;
 
 	DebugStats debugStats;
 	std::map<const char*, UIText*> debugStatsTextMap;
@@ -108,7 +109,7 @@ private:
 	void delay(int ms);
 	void drawScene();
 	void drawTriangle(Triangle& triangle);
-	Vec3 getTriangleVertexColorIntensity(const Triangle& triangle, const Vertex2d& vertex);
+	Vec3 getTriangleVertexColorIntensity(const Triangle& triangle, int vertexIndex);
 	void handleEvent(const SDL_Event& event);
 	void handleKeyDown(const SDL_Keycode& code);
 	void handleKeyUp(const SDL_Keycode& code);
@@ -116,13 +117,14 @@ private:
 	void illuminateColorTriangle(Triangle& triangle);
 	void illuminateTextureTriangle(Triangle& triangle);
 
-	void projectTriangle(
+	void projectAndQueueTriangle(
 		const Vertex3d (&vertexes)[3],
 		const Vec3 (&unitVecs)[3],
 		const Vec3 (&worldVecs)[3],
-		const Vec3& normal,
-		const TextureBuffer* texture,
-		float scale
+		const Object* sourceObject,
+		const Polygon* sourcePolygon,
+		float scale,
+		bool isSynthetic
 	);
 
 	void update();

--- a/Library/System/Geometry.h
+++ b/Library/System/Geometry.h
@@ -3,6 +3,10 @@
 #include <System/Math.h>
 #include <Graphics/Color.h>
 #include <Graphics/TextureBuffer.h>
+#include <map>
+
+struct Polygon;
+struct Object;
 
 /**
  * Vertex2d
@@ -36,8 +40,16 @@ struct Vertex3d : Colorable {
  */
 struct Triangle {
 	Vertex2d vertices[3];
-	Vec3 normal;
-	const TextureBuffer* texture = NULL;
+	Polygon* sourcePolygon = NULL;
+	const Object* sourceObject = NULL;
+
+	/**
+	 * Determines whether the triangle is the result of
+	 * a polygon clipped against the near plane. Synthetic
+	 * triangles are not subject to light caching due to
+	 * their ephemeral nature.
+	 */
+	bool isSynthetic = false;
 
 	float averageZ() const;
 };
@@ -49,6 +61,9 @@ struct Triangle {
 struct Polygon {
 	Vertex3d* vertices[3];
 	Vec3 normal;
+	std::map<int, Vec3> vertexLightCache[3];
+
+	~Polygon();
 
 	void bindVertex(int index, Vertex3d* vertex);
 };

--- a/Library/System/Level.h
+++ b/Library/System/Level.h
@@ -16,6 +16,7 @@ struct Settings {
 	Color ambientLightColor = { 0, 0, 0 };
 	Vec3 ambientLightVector = { 0, -1, 0 };
 	float ambientLightFactor = 1.0f;
+	bool hasStaticAmbientLight = false;
 	float brightness = 1.0f;
 	int visibility = INT_MAX;
 };

--- a/Library/System/Math.h
+++ b/Library/System/Math.h
@@ -48,6 +48,7 @@ struct Vec3 {
 	Vec3 operator -(const Vec3& vector) const;
 	Vec3 operator *(float scalar) const;
 	Vec3 operator *=(float scalar);
+	Vec3 operator *=(const Vec3& vector);
 };
 
 /**

--- a/Library/System/Objects.h
+++ b/Library/System/Objects.h
@@ -14,12 +14,14 @@
  * ------
  */
 struct Object {
+	bool isStatic = false;
 	Vec3 position;
 	TextureBuffer* texture = NULL;
 
 	Object();
 	virtual ~Object();
 
+	int getId() const;
 	const std::vector<Polygon>& getPolygons() const;
 	int getPolygonCount() const;
 	int getVertexCount() const;
@@ -41,6 +43,7 @@ protected:
 
 private:
 	std::vector<Polygon> polygons;
+	int id;
 
 	static Vec3 computePolygonNormal(const Polygon& polygon);
 };
@@ -87,8 +90,8 @@ private:
  */
 struct Light : Object {
 	float power = 1.0f;
-	bool disabled = false;
-	float spread = 500;
+	float range = 500;
+	bool isDisabled = false;
 
 	static bool isLight(Object* object);
 	const Color& getColor() const;

--- a/Source/Graphics/Rasterizer.cpp
+++ b/Source/Graphics/Rasterizer.cpp
@@ -314,7 +314,7 @@ void Rasterizer::triangle(Triangle& triangle) {
 	Vertex2d* top = &triangle.vertices[0];
 	Vertex2d* middle = &triangle.vertices[1];
 	Vertex2d* bottom = &triangle.vertices[2];
-	const TextureBuffer* texture = triangle.texture;
+	const TextureBuffer* texture = triangle.sourceObject->texture;
 
 	if (top->coordinate.y > middle->coordinate.y) swap(top, middle);
 	if (middle->coordinate.y > bottom->coordinate.y) swap(middle, bottom);

--- a/Source/System/Geometry.cpp
+++ b/Source/System/Geometry.cpp
@@ -47,6 +47,12 @@ float Triangle::averageZ() const {
  * Polygon
  * -------
  */
+Polygon::~Polygon() {
+	for (int i = 0; i < 3; i++) {
+		vertexLightCache[i].clear();
+	}
+}
+
 void Polygon::bindVertex(int index, Vertex3d* vertex) {
 	vertices[index] = vertex;
 }

--- a/Source/System/Math.cpp
+++ b/Source/System/Math.cpp
@@ -161,3 +161,11 @@ Vec3 Vec3::operator *=(float scalar) {
 
 	return *this;
 }
+
+Vec3 Vec3::operator *=(const Vec3& vector) {
+	x *= vector.x;
+	y *= vector.y;
+	z *= vector.z;
+
+	return *this;
+}

--- a/Source/System/Objects.cpp
+++ b/Source/System/Objects.cpp
@@ -9,7 +9,9 @@
  * A base class used for 3D objects. Subclasses offer more
  * specialized types of Objects with custom geometry.
  */
-Object::Object() {}
+Object::Object() {
+	id = rand() % 30000;
+}
 
 Object::~Object() {
 	polygons.clear();
@@ -72,6 +74,10 @@ void Object::computeSurfaceNormals() {
 	for (auto& polygon : polygons) {
 		polygon.normal = Object::computePolygonNormal(polygon);
 	}
+}
+
+int Object::getId() const {
+	return id;
 }
 
 int Object::getPolygonCount() const {


### PR DESCRIPTION
Objects and Lights can now be marked as static using the `isStatic` flag. Ambient lighting can also be set as static using `settings.hasStaticAmbientLighting = true`.

If an object/light source combination are both static, the computed per-vertex + per-light intensity values for that object are cached and reused on subsequent frames. This means the memory footprint is a little heavier (each static vertex stores a floating-point 3-vector for each static light which hits it), but the framerate can improve with a substantial enough number of static light sources and light-incident objects. The option to toggle the static nature of lights or objects also provides finer control over the degree of optimization.

These are hardly scientific examples (the framerate tends to fluctuate a fair bit), but a few before-and-after pictures help demonstrate the improvement:

---

**Before**:
![garden-lc-before](https://user-images.githubusercontent.com/9344964/52909087-a8f1da80-3247-11e9-86a3-49b08cd7a34c.png)

**After**:
![garden-lc-after](https://user-images.githubusercontent.com/9344964/52909091-caeb5d00-3247-11e9-99a9-9d3727cce8de.png)

---

**Before**:
![lighttest-lc-before](https://user-images.githubusercontent.com/9344964/52909098-d8084c00-3247-11e9-83bc-52f7988b4306.png)


**After**:
![lighttest-lc-after](https://user-images.githubusercontent.com/9344964/52909103-ec4c4900-3247-11e9-93f8-8cbedbc36a8a.png)

---

**Before**:
![stresstest-lc-before](https://user-images.githubusercontent.com/9344964/52909105-f79f7480-3247-11e9-82d7-3dc5a7905473.png)

**After**:
![stresstest-lc-after](https://user-images.githubusercontent.com/9344964/52909107-fcfcbf00-3247-11e9-8b2f-d2a903a0fb6c.png)

---

I'd be curious to know what the performance difference is on your machine, since we established that our baseline performance isn't quite the same.