### PR TITLE
Particle systems + weather effects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,13 +50,14 @@ set(SOURCE_FILES
     Library/Graphics/TextureBuffer.h
     Library/Loaders/Loader.h
     Library/Loaders/ObjLoader.h
+    Library/System/DebugStats.h
     Library/System/Flags.h
     Library/System/Geometry.h
     Library/System/Level.h
     Library/System/Math.h
     Library/System/Objects.h
+    Library/System/ParticleSystem.h
     Library/System/Quaternion.h
-    Library/System/DebugStats.h
     Library/UI/UI.h
     Library/UI/UIObjects.h
     Library/Engine.h
@@ -70,15 +71,17 @@ set(SOURCE_FILES
     Source/Graphics/TextureBuffer.cpp
     Source/Loaders/Loader.cpp
     Source/Loaders/ObjLoader.cpp
+    Source/System/DebugStats.cpp
     Source/System/Geometry.cpp
     Source/System/Level.cpp
     Source/System/Math.cpp
     Source/System/Objects.cpp
+    Source/System/ParticleSystem.cpp
     Source/System/Quaternion.cpp
-    Source/System/DebugStats.cpp
     Source/UI/UI.cpp
     Source/UI/UIObjects.cpp
     Source/Engine.cpp
+    Source/Helpers.cpp
 )
 
 add_executable(${EXECUTABLE_NAME} ${SOURCE_FILES})

--- a/Demo/Levels/Default.cpp
+++ b/Demo/Levels/Default.cpp
@@ -56,7 +56,7 @@ void Default::load() {
 	settings.ambientLightFactor = 0.5;
 }
 
-void Default::update(int dt, int runningTime) {
+void Default::onUpdate(int dt, int runningTime) {
 	getObject("oscillatingCube")->position.y = 200.0f + 100.0f * sinf(runningTime / 500.0f);
 
 	Light* light = (Light*)getObject("light");

--- a/Demo/Levels/Default.h
+++ b/Demo/Levels/Default.h
@@ -5,5 +5,5 @@
 class Default : public Level {
 public:
 	void load() override;
-	void update(int dt, int runningTime) override;
+	void onUpdate(int dt, int runningTime) override;
 };

--- a/Demo/Levels/Garden.cpp
+++ b/Demo/Levels/Garden.cpp
@@ -74,15 +74,16 @@ void Garden::load() {
 
 	ParticleSystem* snow = new ParticleSystem(2000);
 
-	snow->setRange(
-		{ -2500, 2000, 0 },
-		{ 2500, 0, 5000 }
+	snow->setSpawnRange(
+		{ -2500.0f, 2500.0f },
+		{ 0.0f, 2000.0f },
+		{ 0.0f, 5000.0f }
 	);
 
 	snow->setParticleColor({ 255, 255, 255 });
 	snow->setParticleSize(5, 5);
 
-	snow->setBehavior([=](Particle* particle, int dt) {
+	snow->setParticleBehavior([=](Particle* particle, int dt) {
 		particle->position.y -= (float)dt / 5.0f;
 
 		if (particle->position.y < -100) {

--- a/Demo/Levels/Garden.cpp
+++ b/Demo/Levels/Garden.cpp
@@ -1,6 +1,7 @@
 #include <Levels/Garden.h>
 #include <Graphics/TextureBuffer.h>
 #include <System/Objects.h>
+#include <System/ParticleSystem.h>
 #include <cmath>
 
 /**
@@ -10,7 +11,6 @@
 void Garden::load() {
 	ObjLoader treeObj("./DemoAssets/tree-model.obj");
 	ObjLoader icoObj("./DemoAssets/da-vinci.obj");
-	ObjLoader teapotObj("./DemoAssets/teapot.obj");
 
 	add("tree-texture", new TextureBuffer("./DemoAssets/tree-texture.png"));
 	add("ground-texture", new TextureBuffer("./DemoAssets/ground-texture.png"));
@@ -55,13 +55,13 @@ void Garden::load() {
 
 	add("movingLight", movingLight);
 
-	Model* teapot = new Model(teapotObj);
-	teapot->setColor(255, 255, 255);
-	teapot->position = { -1000, 10, 2000 };
-	teapot->scale(50);
-	teapot->isStatic = true;
+	Model* icosahedron = new Model(icoObj);
+	icosahedron->setColor(255, 255, 255);
+	icosahedron->position = { 0, 150, 2500 };
+	icosahedron->scale(200);
+	icosahedron->isStatic = true;
 
-	add(teapot);
+	add(icosahedron);
 
 	Mesh* mesh = new Mesh(50, 50, 100);
 	mesh->setColor(10, 5, 0);
@@ -72,16 +72,36 @@ void Garden::load() {
 
 	add(mesh);
 
-	settings.backgroundColor = { 0, 0, 0 };
-	// settings.visibility = 4000;
-	settings.brightness = 0.2;
-	settings.ambientLightColor = { 0, 0, 255 };
-	settings.ambientLightVector = { 0, -0.1, 1 };
-	settings.ambientLightFactor = 1;
+	ParticleSystem* snow = new ParticleSystem(2000);
+
+	snow->setRange(
+		{ -2500, 2000, 0 },
+		{ 2500, 0, 5000 }
+	);
+
+	snow->setParticleColor({ 255, 255, 255 });
+	snow->setParticleSize(5, 5);
+
+	snow->setBehavior([=](Particle* particle, int dt) {
+		particle->position.y -= (float)dt / 5.0f;
+
+		if (particle->position.y < -100) {
+			particle->shouldReset = true;
+		}
+	});
+
+	addParticleSystem("snow", snow);
+
+	settings.backgroundColor = { 0, 10, 20 };
+	settings.visibility = 3500;
+	settings.brightness = 0.1;
+	settings.ambientLightColor = { 0, 0, 100 };
+	settings.ambientLightVector = { 0, -0.8f, 0.5f };
+	settings.ambientLightFactor = 0.5f;
 	settings.hasStaticAmbientLight = true;
 }
 
-void Garden::update(int dt, int runningTime) {
+void Garden::onUpdate(int dt, int runningTime) {
 	Light* movingLight = (Light*)getObject("movingLight");
 
 	movingLight->position.x = 1500.0f * sinf(runningTime / 900.0f);

--- a/Demo/Levels/Garden.h
+++ b/Demo/Levels/Garden.h
@@ -5,5 +5,5 @@
 class Garden : public Level {
 public:
 	void load() override;
-	void update(int dt, int runningTime) override;
+	void onUpdate(int dt, int runningTime) override;
 };

--- a/Demo/Levels/LightTest.cpp
+++ b/Demo/Levels/LightTest.cpp
@@ -117,7 +117,7 @@ void LightTest::load() {
 	settings.hasStaticAmbientLight = true;
 }
 
-void LightTest::update(int dt, int runningTime) {
+void LightTest::onUpdate(int dt, int runningTime) {
 	Light* light = (Light*)getObject("yellowLight");
 
 	light->power = 1.0f + cosf(runningTime / 500.0f);

--- a/Demo/Levels/LightTest.h
+++ b/Demo/Levels/LightTest.h
@@ -5,5 +5,5 @@
 class LightTest : public Level {
 public:
 	void load() override;
-	void update(int dt, int runningTime) override;
+	void onUpdate(int dt, int runningTime) override;
 };

--- a/Demo/Levels/TextureTest.cpp
+++ b/Demo/Levels/TextureTest.cpp
@@ -38,7 +38,7 @@ void TextureTest::load() {
 	// settings.visibility = 2500;
 }
 
-void TextureTest::update(int dt, int runningTime) {
+void TextureTest::onUpdate(int dt, int runningTime) {
 	// getObject("spinningCube")->rotate({ 0.02, -0.03, 0 });
 }
 

--- a/Demo/Levels/TextureTest.h
+++ b/Demo/Levels/TextureTest.h
@@ -5,5 +5,5 @@
 class TextureTest : public Level {
 public:
 	void load() override;
-	void update(int dt, int runningTime) override;
+	void onUpdate(int dt, int runningTime) override;
 };

--- a/Library/Engine.h
+++ b/Library/Engine.h
@@ -82,7 +82,7 @@ public:
 	void run();
 
 private:
-	constexpr static float NEAR_Z = 10.0f;
+	constexpr static float NEAR_Z = 30.0f;
 	constexpr static int MOVEMENT_SPEED = 5;
 	constexpr static int AMBIENT_LIGHT_ID = 0;
 

--- a/Library/Graphics/Rasterizer.h
+++ b/Library/Graphics/Rasterizer.h
@@ -18,6 +18,7 @@ public:
 	~Rasterizer();
 
 	void clear();
+	int getTotalScanlines();
 	void line(int x1, int y1, int x2, int y2);
 	void render(SDL_Renderer* renderer, int sizeFactor);
 	void setBackgroundColor(const Color& color);

--- a/Library/Helpers.h
+++ b/Library/Helpers.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <random>
+#include <math.h>
+
 /**
  * Preprocessors for speeding up code when built in Visual Studio.
  */
@@ -16,4 +19,8 @@ namespace Lerp {
 	inline float lerp(float v1, float v2, float ratio) {
 		return v1 + (v2 - v1) * ratio;
 	}
-}
+};
+
+namespace RNG {
+	float random(float low, float high);
+};

--- a/Library/System/Level.h
+++ b/Library/System/Level.h
@@ -4,9 +4,10 @@
 #include <vector>
 #include <limits.h>
 #include <System/Objects.h>
+#include <System/ParticleSystem.h>
 #include <Graphics/TextureBuffer.h>
 
-enum State {
+enum LevelState {
 	ACTIVE,
 	INACTIVE
 };
@@ -27,13 +28,16 @@ struct Settings {
  */
 class Level {
 public:
+	~Level();
+
 	const std::vector<Object*>& getObjects();
 	const std::vector<Light*>& getLights();
 	const Settings& getSettings();
 	bool hasQuit();
 	virtual void load() = 0;
+	virtual void onUpdate(int dt, int runningTime);
 	void quit();
-	virtual void update(int dt, int runningTime);
+	void update(int dt);
 
 protected:
 	Settings settings;
@@ -42,6 +46,7 @@ protected:
 	void add(const char* key, Object* object);
 	void add(const char* key, ObjLoader* objLoader);
 	void add(const char* key, TextureBuffer* textureBuffer);
+	void addParticleSystem(const char* key, ParticleSystem* particleSystem);
 	Object* getObject(const char* key);
 	ObjLoader* getObjLoader(const char* key);
 	TextureBuffer* getTexture(const char* key);
@@ -53,13 +58,14 @@ private:
 	std::map<const char*, int> objectMap;
 	std::map<const char*, ObjLoader*> objLoaderMap;
 	std::map<const char*, TextureBuffer*> textureBufferMap;
-	State state = State::ACTIVE;
+	std::map<const char*, ParticleSystem*> particleSystemMap;
+	LevelState state = LevelState::ACTIVE;
 
 	template<class T>
 	T* getMapItem(std::map<const char*, T*> map, const char* key);
-
 	void removeLight(Light* light);
-
 	template<class T>
 	void removeMapItem(std::map<const char*, T*> map, const char* key);
+	void safelyRemoveKeyedObject(const char* key);
+	void safelyRemoveKeyedParticleSystem(const char* key);
 };

--- a/Library/System/Objects.h
+++ b/Library/System/Objects.h
@@ -16,6 +16,7 @@
 struct Object {
 	bool isStatic = false;
 	Vec3 position;
+	Vec3 velocity;
 	TextureBuffer* texture = NULL;
 
 	Object();
@@ -25,12 +26,20 @@ struct Object {
 	const std::vector<Polygon>& getPolygons() const;
 	int getPolygonCount() const;
 	int getVertexCount() const;
+
+	template<class T>
+	bool isOfType() {
+		return dynamic_cast<T*>(this) != NULL;
+	}
+
 	void rotate(const Vec3& rotation);
 	void rotateDeg(const Vec3& rotation);
 	void scale(float scalar);
+	void scale(const Vec3& vector);
 	void setColor(int R, int G, int B);
 	void setColor(const Color& color);
 	void setTexture(TextureBuffer* textureBuffer);
+	void update(int dt);
 
 protected:
 	std::vector<Vertex3d> vertices;
@@ -85,6 +94,16 @@ private:
 };
 
 /**
+ * Particle
+ * --------
+ */
+struct Particle : Object {
+	bool shouldReset = true;
+
+	Particle();
+};
+
+/**
  * Light
  * -----
  */
@@ -93,7 +112,6 @@ struct Light : Object {
 	float range = 500;
 	bool isDisabled = false;
 
-	static bool isLight(Object* object);
 	const Color& getColor() const;
 	const Vec3& getColorRatios() const;
 	void setColor(int R, int G, int B);

--- a/Library/System/ParticleSystem.h
+++ b/Library/System/ParticleSystem.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <System/Objects.h>
+#include <Graphics/Color.h>
+#include <Graphics/TextureBuffer.h>
+#include <functional>
+#include <vector>
+
+/**
+ * ParticleSystem
+ * --------------
+ */
+class ParticleSystem {
+public:
+	ParticleSystem(int size);
+	~ParticleSystem();
+
+	const std::vector<Particle*>& getParticles() const;
+	void setBehavior(std::function<void(Particle*, int)> handler);
+	void setLocation(const Vec3 location);
+	void setParticleColor(const Color& color);
+	void setParticleSize(float width, float height);
+	void setParticleTexture(TextureBuffer* texture);
+	void setRange(const Vec3 r1, const Vec3 r2);
+	void update(int dt);
+
+private:
+	std::vector<Particle*> particles;
+	std::function<void(Particle*, int)> behaviorHandler;
+	Vec3 range[2];
+
+	void resetParticle(Particle* particle);
+};

--- a/Library/System/ParticleSystem.h
+++ b/Library/System/ParticleSystem.h
@@ -3,6 +3,7 @@
 #include <System/Objects.h>
 #include <Graphics/Color.h>
 #include <Graphics/TextureBuffer.h>
+#include <System/Math.h>
 #include <functional>
 #include <vector>
 
@@ -16,18 +17,20 @@ public:
 	~ParticleSystem();
 
 	const std::vector<Particle*>& getParticles() const;
-	void setBehavior(std::function<void(Particle*, int)> handler);
-	void setLocation(const Vec3 location);
+	void setParticleBehavior(std::function<void(Particle*, int)> handler);
 	void setParticleColor(const Color& color);
 	void setParticleSize(float width, float height);
 	void setParticleTexture(TextureBuffer* texture);
-	void setRange(const Vec3 r1, const Vec3 r2);
+	void setSpawnLocation(const Vec3& location);
+	void setSpawnRange(const Range<float> xSpawnRange, const Range<float> ySpawnRange, const Range<float> zSpawnRange);
 	void update(int dt);
 
 private:
 	std::vector<Particle*> particles;
 	std::function<void(Particle*, int)> behaviorHandler;
-	Vec3 range[2];
+	Range<float> xSpawnRange = { 0.0f, 0.0f };
+	Range<float> ySpawnRange = { 0.0f, 0.0f };
+	Range<float> zSpawnRange = { 0.0f, 0.0f };
 
 	void resetParticle(Particle* particle);
 };

--- a/README.md
+++ b/README.md
@@ -5,18 +5,15 @@ A software 3D rendering engine, written as an educational exercise.
 
 ### Features
 
-* 2D sprite projection
-* Ambient/atmospheric effects (rain, snow, fog)
 * Stereo/surround sound
 * OpenGL/hardware mode
 
 **Pending optimizations:**
 
 * Cache ambient light color ratios
-* Separate illumination & rasterization steps/consider options for parallel illumination
 * Skip texture sampling on surfaces with insufficient illumination
 * Staggered perspective-correct/linear UV interpolation
-* Texture sampling distance cleanup
+* Texture sampling logic cleanup
 
 **Maybe:**
 

--- a/Source/Engine.cpp
+++ b/Source/Engine.cpp
@@ -555,7 +555,8 @@ void Engine::run() {
 
 		int delta = SDL_GetTicks() - lastStartTime;
 
-		activeLevel->update(delta, SDL_GetTicks());
+		activeLevel->update(delta);
+		activeLevel->onUpdate(delta, SDL_GetTicks());
 
 		SDL_Event event;
 
@@ -628,6 +629,7 @@ void Engine::addDebugStats() {
 	addDebugStat("totalTriangles");
 	addDebugStat("totalTrianglesProjected");
 	addDebugStat("totalTrianglesDrawn");
+	addDebugStat("totalScanlines");
 }
 
 void Engine::updateDebugStats() {
@@ -639,6 +641,7 @@ void Engine::updateDebugStats() {
 	updateDebugStat("totalTriangles", "Triangles", debugStats.getTotalPolygons(activeLevel->getObjects()));
 	updateDebugStat("totalTrianglesProjected", "Triangles projected", debugStats.getTotalProjectedTriangles());
 	updateDebugStat("totalTrianglesDrawn", "Triangles drawn", debugStats.getTotalDrawnTriangles());
+	updateDebugStat("totalScanlines", "Scanlines", rasterizer->getTotalScanlines());
 }
 
 void Engine::addDebugStat(const char* key) {

--- a/Source/Graphics/Rasterizer.cpp
+++ b/Source/Graphics/Rasterizer.cpp
@@ -197,6 +197,10 @@ int Rasterizer::getTextureSampleInterval(int tex_w, int tex_h, int lineLength, f
 	}
 }
 
+int Rasterizer::getTotalScanlines() {
+	return totalBufferedScanlines;
+}
+
 int Rasterizer::manageScanlineThread(void* data) {
 	ScanlineThreadManager* manager = (ScanlineThreadManager*)data;
 	Rasterizer* rasterizer = manager->rasterizer;

--- a/Source/Helpers.cpp
+++ b/Source/Helpers.cpp
@@ -1,0 +1,14 @@
+#include <Helpers.h>
+#include <random>
+#include <math.h>
+
+namespace RNG {
+	namespace {
+		std::default_random_engine engine;
+		std::uniform_real_distribution<float> floatDistribution(0.0f, 1.0f);
+	};
+
+	float random(float low, float high) {
+		return low + floor(floatDistribution(engine) * (high - low) + 1);
+	}
+};

--- a/Source/System/Level.cpp
+++ b/Source/System/Level.cpp
@@ -109,11 +109,16 @@ void Level::quit() {
 		delete textureBuffer;
 	}
 
+	for (auto& [key, particleSystem] : particleSystemMap) {
+		delete particleSystem;
+	}
+
 	objects.clear();
 	lights.clear();
 	objectMap.clear();
 	objLoaderMap.clear();
 	textureBufferMap.clear();
+	particleSystemMap.clear();
 
 	state = LevelState::INACTIVE;
 }
@@ -194,9 +199,8 @@ void Level::safelyRemoveKeyedParticleSystem(const char* key) {
 	if (entry != particleSystemMap.end()) {
 		ParticleSystem* particleSystem = particleSystemMap.at(key);
 		const std::vector<Particle*>& particles = particleSystem->getParticles();
-		int totalParticles = particles.size();
 		Particle* firstParticle = particles.at(0);
-
+		int totalParticles = particles.size();
 		int idx = 0;
 
 		while (idx < objects.size()) {

--- a/Source/System/Objects.cpp
+++ b/Source/System/Objects.cpp
@@ -126,6 +126,14 @@ void Object::scale(float scalar) {
 	}
 }
 
+void Object::scale(const Vec3& vector) {
+	for (auto& vertex : vertices) {
+		vertex.vector.x *= vector.x;
+		vertex.vector.y *= vector.y;
+		vertex.vector.z *= vector.z;
+	}
+}
+
 void Object::setColor(int R, int G, int B) {
 	for (int i = 0; i < vertices.size(); i++) {
 		vertices.at(i).color = { R, G, B };
@@ -134,6 +142,10 @@ void Object::setColor(int R, int G, int B) {
 
 void Object::setColor(const Color& color) {
 	setColor(color.R, color.G, color.B);
+}
+
+void Object::update(int dt) {
+
 }
 
 /**
@@ -409,6 +421,27 @@ void Cube::setFaceUVCoordinates(float x1, float y1, float x2, float y2) {
 }
 
 /**
+ * Particle
+ * --------
+ *
+ * Creates a simple flat surface used for particle effects.
+ */
+Particle::Particle() {
+	addVertex({ -1, 1, 0 });
+	addVertex({ 1, 1, 0 });
+	addVertex({ -1, -1, 0 });
+	addVertex({ 1, -1, 0 });
+
+	// 'Front' face
+	addPolygon(0, 2, 1);
+	addPolygon(1, 2, 3);
+
+	// 'Back' face
+	addPolygon(0, 1, 2);
+	addPolygon(1, 3, 2);
+}
+
+/**
  * Light
  * -----
  */
@@ -418,10 +451,6 @@ const Color& Light::getColor() const {
 
 const Vec3& Light::getColorRatios() const {
 	return cachedColorRatios;
-}
-
-bool Light::isLight(Object* object) {
-	return dynamic_cast<Light*>(object) != NULL;
 }
 
 void Light::setColor(int R, int G, int B) {

--- a/Source/System/ParticleSystem.cpp
+++ b/Source/System/ParticleSystem.cpp
@@ -29,21 +29,17 @@ const std::vector<Particle*>& ParticleSystem::getParticles() const {
 
 void ParticleSystem::resetParticle(Particle* particle) {
 	Vec3 newPosition = {
-		RNG::random(range[0].x, range[1].x),
-		RNG::random(range[0].y, range[1].y),
-		RNG::random(range[0].z, range[1].z)
+		RNG::random(xSpawnRange.start, xSpawnRange.end),
+		RNG::random(ySpawnRange.start, ySpawnRange.end),
+		RNG::random(zSpawnRange.start, zSpawnRange.end)
 	};
 
 	particle->position = newPosition;
 	particle->shouldReset = false;
 }
 
-void ParticleSystem::setBehavior(std::function<void(Particle*, int)> handler) {
+void ParticleSystem::setParticleBehavior(std::function<void(Particle*, int)> handler) {
 	behaviorHandler = handler;
-}
-
-void ParticleSystem::setLocation(const Vec3 location) {
-	setRange(location, location);
 }
 
 void ParticleSystem::setParticleColor(const Color& color) {
@@ -64,9 +60,21 @@ void ParticleSystem::setParticleTexture(TextureBuffer* texture) {
 	}
 }
 
-void ParticleSystem::setRange(const Vec3 r1, const Vec3 r2) {
-	range[0] = r1;
-	range[1] = r2;
+void ParticleSystem::setSpawnLocation(const Vec3& location) {
+	xSpawnRange.start = location.x;
+	xSpawnRange.end = location.x;
+
+	ySpawnRange.start = location.y;
+	ySpawnRange.end = location.y;
+
+	zSpawnRange.start = location.z;
+	zSpawnRange.end = location.z;
+}
+
+void ParticleSystem::setSpawnRange(const Range<float> xSpawnRange, const Range<float> ySpawnRange, const Range<float> zSpawnRange) {
+	this->xSpawnRange = xSpawnRange;
+	this->ySpawnRange = ySpawnRange;
+	this->zSpawnRange = zSpawnRange;
 }
 
 void ParticleSystem::update(int dt) {

--- a/Source/System/ParticleSystem.cpp
+++ b/Source/System/ParticleSystem.cpp
@@ -1,0 +1,80 @@
+#include <System/ParticleSystem.h>
+#include <System/Objects.h>
+#include <Graphics/Color.h>
+#include <Graphics/TextureBuffer.h>
+#include <Helpers.h>
+#include <functional>
+
+/**
+ * ParticleSystem
+ * --------------
+ */
+ParticleSystem::ParticleSystem(int size) {
+	for (int i = 0; i < size; i++) {
+		particles.push_back(new Particle());
+	}
+}
+
+ParticleSystem::~ParticleSystem() {
+	for (auto* particle : particles) {
+		delete particle;
+	}
+
+	particles.clear();
+}
+
+const std::vector<Particle*>& ParticleSystem::getParticles() const {
+	return particles;
+}
+
+void ParticleSystem::resetParticle(Particle* particle) {
+	Vec3 newPosition = {
+		RNG::random(range[0].x, range[1].x),
+		RNG::random(range[0].y, range[1].y),
+		RNG::random(range[0].z, range[1].z)
+	};
+
+	particle->position = newPosition;
+	particle->shouldReset = false;
+}
+
+void ParticleSystem::setBehavior(std::function<void(Particle*, int)> handler) {
+	behaviorHandler = handler;
+}
+
+void ParticleSystem::setLocation(const Vec3 location) {
+	setRange(location, location);
+}
+
+void ParticleSystem::setParticleColor(const Color& color) {
+	for (auto* particle : particles) {
+		particle->setColor(color);
+	}
+}
+
+void ParticleSystem::setParticleSize(float width, float height) {
+	for (auto* particle : particles) {
+		particle->scale({ width / 2.0f, height / 2.0f, 1.0f });
+	}
+}
+
+void ParticleSystem::setParticleTexture(TextureBuffer* texture) {
+	for (auto* particle : particles) {
+		particle->setTexture(texture);
+	}
+}
+
+void ParticleSystem::setRange(const Vec3 r1, const Vec3 r2) {
+	range[0] = r1;
+	range[1] = r2;
+}
+
+void ParticleSystem::update(int dt) {
+	for (auto* particle : particles) {
+		if (particle->shouldReset) {
+			resetParticle(particle);
+		}
+
+		behaviorHandler(particle, dt);
+	}
+}


### PR DESCRIPTION
Adds support for particle systems with configurable behavior. The intent with this one was to use particle systems for weather effects like rain or snow, but in principle they could be used for other things.

`Particle` objects are a new `Object` subtype used in particle systems. They are simple flat squares. Rather than use 2D sprites for particles, which would require a separate projection/illumination/rendering pipeline to regular geometry, I opted to keep them as actual 3D objects.

![rain](https://user-images.githubusercontent.com/9344964/52991247-8095e780-33d1-11e9-8c66-344ca24d5553.png)

![raster20](https://user-images.githubusercontent.com/9344964/52991253-88558c00-33d1-11e9-8a9a-392d9f5b7175.png)
